### PR TITLE
:sparkles: TabSettingsDialog documented and fixed

### DIFF
--- a/dial_gui/widgets/editor_tabwidget/editor_tabwidget.py
+++ b/dial_gui/widgets/editor_tabwidget/editor_tabwidget.py
@@ -3,13 +3,12 @@
 from typing import TYPE_CHECKING
 
 import dependency_injector.providers as providers
-from PySide2.QtCore import QEvent
-from PySide2.QtGui import QIcon, QPixmap
-from PySide2.QtWidgets import QStackedWidget, QTabBar, QTabWidget, QWidget
-
 from dial_gui.node_editor import NodeEditorWindowFactory
 from dial_gui.node_editor.nodes_windows import NodesWindow
 from dial_gui.project import ProjectManagerGUISingleton
+from PySide2.QtCore import QEvent
+from PySide2.QtGui import QIcon, QPixmap
+from PySide2.QtWidgets import QStackedWidget, QTabBar, QTabWidget, QWidget
 
 from .tab_settings_dialog import TabSettingsDialog
 
@@ -43,13 +42,13 @@ class CustomTabWidget(QTabWidget):
                 self.__tab_renamer_dialog = TabSettingsDialog(
                     index=index,
                     name=widget.name,
-                    current_color=widget.color_identifier,
+                    color=widget.color_identifier,
                     parent=self,
                 )
-                self.__tab_renamer_dialog.current_color_changed.connect(
+                self.__tab_renamer_dialog.color_changed.connect(
                     self.__tab_color_changed
                 )
-                self.__tab_renamer_dialog.current_name_changed.connect(
+                self.__tab_renamer_dialog.name_changed.connect(
                     self.__tab_name_changed
                 )
                 self.__tab_renamer_dialog.show()

--- a/dial_gui/widgets/editor_tabwidget/tab_settings_dialog.py
+++ b/dial_gui/widgets/editor_tabwidget/tab_settings_dialog.py
@@ -1,6 +1,8 @@
 # vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
 
-from PySide2.QtCore import Signal
+from typing import TYPE_CHECKING
+
+from PySide2.QtCore import Qt, Signal
 from PySide2.QtGui import QColor
 from PySide2.QtWidgets import (
     QColorDialog,
@@ -11,63 +13,107 @@ from PySide2.QtWidgets import (
     QWidget,
 )
 
+if TYPE_CHECKING:
+    from PySide2.QtWidgets import QKeyEvent
+
 
 class TabSettingsDialog(QDialog):
-    current_color_changed = Signal(int, QColor)
-    current_name_changed = Signal(int, str)
+    """The TabSettingsDialog class provides a dialog for picking a new color and name
+    for an EditorTabWidget object.
+
+    Attributes:
+        name: Current name of the tab.
+        Color: Current color of the tab.
+    """
+
+    color_changed = Signal(int, QColor)
+    name_changed = Signal(int, str)
 
     def __init__(
         self,
         index=-1,
         name="",
-        current_color=QColor("#FFFFFF"),
+        color=QColor("#FFFFFF"),
         parent: "QWidget" = None,
     ):
         super().__init__(parent)
 
         self.setWindowTitle("Tab settings")
 
+        # Attributes
         self.index = index
         self.__name = name
-        self.__current_color = current_color
+        self.__color = color
 
-        self.__color_picker_dialog = QColorDialog(parent=self)
-        self.__color_picker_dialog.setCurrentColor(self.__current_color)
+        # Color picker
+        self.__color_picker_dialog = QColorDialog(parent)
+        self.__color_picker_dialog.setCurrentColor(self.__color)
         self.__color_picker_dialog.currentColorChanged.connect(
-            lambda color: self.current_color_changed.emit(self.index, color)
+            lambda color: self.color_changed.emit(self.index, color)
         )
         self.__color_picker_dialog.finished.connect(self.done)
 
+        # Button for displaying the color picker
         self.__show_color_picker_button = QPushButton(
-            "Color...", default=False, autoDefault=False, parent=self
+            "Color...", default=False, autoDefault=False
         )
         self.__show_color_picker_button.clicked.connect(
             lambda: self.__color_picker_dialog.show()
         )
 
+        # Name edit
         self.__name_line_edit = QLineEdit(self.__name, parent=self)
+        self.__name_line_edit.setFocus(Qt.PopupFocusReason)
         self.__name_line_edit.textEdited.connect(
-            lambda new_text: self.current_name_changed.emit(self.index, new_text)
+            lambda new_text: self.name_changed.emit(self.index, new_text)
         )
 
+        # Configure layout
         self.__main_layout = QHBoxLayout()
         self.__main_layout.addWidget(self.__show_color_picker_button)
         self.__main_layout.addWidget(self.__name_line_edit)
         self.setLayout(self.__main_layout)
 
     @property
-    def name(self):
+    def name(self) -> "str":
+        """Returns the current name of the tab."""
         return self.__name
 
     @name.setter
     def name(self, name: str):
+        """Sets a new name for the tab (programatically).
+
+        Sends a `name_changed` signal.
+        """
         self.__name = name
         self.__name_line_edit.setText(self.__name)
+        self.name_changed.emit(self.index, self.name)
 
     @property
-    def current_color(self):
+    def color(self) -> "QColor":
+        """Returns the current color picked for the tab."""
         return self.__color_picker_dialog.currentColor()
 
-    @current_color.setter
-    def current_color(self, color):
+    @color.setter
+    def color(self, color):
+        """Sets a new color for the tab (programatically).
+
+        Sends a `color_changed` signal.
+        """
         self.__color_picker_dialog.setCurrentColor(color)
+
+    def accept(self):
+        """When the dialog is accepted (Closed saving the changes), send a signal to
+        update the text and color."""
+        self.name_changed.emit(self.index, self.__name_line_edit.text())
+        self.color_changed.emit(
+            self.index, self.__color_picker_dialog.currentColor()
+        )
+        super().accept()
+
+    def keyPressEvent(self, event: "QKeyEvent"):
+        """When the Return key is pressed, accept the dialog."""
+        if event.key() == Qt.Key_Return:
+            self.accept()
+
+        super().keyPressEvent(event)


### PR DESCRIPTION
Now it has focus on dialog start, and can be accepted by pressing Return.

What does this implement/fix? Explain your changes.
---------------------------------------------------
Now the TabSettingsDialog has focus on enter, and can be accepted by pressing Return.

Does this close any currently open issues?
------------------------------------------
Closes #3 