### PR TITLE
:sparkles: Duplicating nodes on view

### DIFF
--- a/dial_gui/node_editor/graphics_port.py
+++ b/dial_gui/node_editor/graphics_port.py
@@ -4,10 +4,9 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import dependency_injector.providers as providers
+from dial_core.node_editor import Port
 from PySide2.QtCore import QRectF
 from PySide2.QtWidgets import QGraphicsItem
-
-from dial_core.node_editor import Port
 
 from .graphics_connection import GraphicsConnection, GraphicsConnectionFactory
 from .graphics_port_painter import GraphicsPortPainterFactory

--- a/dial_gui/node_editor/graphics_scene.py
+++ b/dial_gui/node_editor/graphics_scene.py
@@ -68,6 +68,32 @@ class GraphicsScene(QGraphicsScene):
 
         super().removeItem(item)
 
+    def duplicate_graphics_nodes(self, graphics_nodes: List["GraphicsNode"]):
+        inner_nodes = list(map(lambda x: x._node, graphics_nodes))
+
+        new_duplicated_nodes = self.__scene.duplicate_nodes(inner_nodes)
+
+        new_graphics_nodes = []
+
+        for new_node, old_graphics_node in zip(new_duplicated_nodes, graphics_nodes):
+            graphics_node = self.__create_graphics_node_from(new_node)
+            new_graphics_nodes.append(graphics_node)
+
+            self.__graphics_nodes.append(graphics_node)
+            super().addItem(graphics_node)
+
+            graphics_node.setPos(old_graphics_node.x() + 50, old_graphics_node.y() - 50)
+
+            for graphics_port in list(graphics_node.inputs.values()) + list(
+                graphics_node.outputs.values()
+            ):
+                for graphics_connection in graphics_port.graphics_connections:
+                    print("@GRaphcis", graphics_connection)
+                    # TODO: Solve items duplication with this approach
+                    self.addItem(graphics_connection)
+
+        return new_graphics_nodes
+
     def drawBackground(self, painter: "QPainter", rect: "QRectF"):
         """Draws the background for the scene."""
         super().drawBackground(painter, rect)

--- a/dial_gui/node_editor/node_editor_view_menu.py
+++ b/dial_gui/node_editor/node_editor_view_menu.py
@@ -29,6 +29,9 @@ class NodeEditorViewMenu(QMenu):
         self._remove_elements_act = QAction("Remove nodes", self)
         self._remove_elements_act.triggered.connect(self.__remove_selected_elements)
 
+        self._duplicate_nodes_act = QAction("Duplicate nodes", self)
+        self._duplicate_nodes_act.triggered.connect(self.__duplicate_selected_nodes)
+
         self._add_nodes_to_new_window_act = QAction("Add nodes to new window", self)
         self._add_nodes_to_new_window_act.triggered.connect(
             self.__add_selected_nodes_to_new_window
@@ -57,6 +60,7 @@ class NodeEditorViewMenu(QMenu):
             )
 
         self.addAction(self._remove_elements_act)
+        self.addAction(self._duplicate_nodes_act)
         self.addSeparator()
         self.addAction(self._add_nodes_to_new_window_act)
         self.addAction(self._add_each_node_to_new_window_act)
@@ -98,6 +102,21 @@ class NodeEditorViewMenu(QMenu):
         for graphics_node in graphics_nodes:
             if isinstance(graphics_node, GraphicsNode):
                 window.add_graphics_node(graphics_node)
+
+    def __duplicate_selected_nodes(self):
+        selected_items = self.__graphics_scene.selectedItems()
+        selected_graphics_nodes = list(
+            filter(lambda x: isinstance(x, GraphicsNode), selected_items)
+        )
+
+        new_graphics_nodes = self.__graphics_scene.duplicate_graphics_nodes(
+            selected_graphics_nodes
+        )
+        self.__graphics_scene.clearSelection()
+
+        for graphics_node in new_graphics_nodes:
+            graphics_node.setSelected(True)
+            graphics_node.setZValue(11)
 
 
 NodeEditorViewMenuFactory = providers.Factory(NodeEditorViewMenu)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/dial-app/dial-gui"
 
 [tool.poetry.dependencies]
 python = ">=3.6, <3.8"
-dial-core = "v0.12a0"
+dial-core = "v0.13a0"
 
 tensorflow = "2.0.0b1"
 PySide2 = "^5.12.6"


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds an option to the EditorView menu to duplicate the selected nodes.

Does this close any currently open issues?
------------------------------------------
Closes #6 

Any other comments?
-------------------
Working but needs some refactor. Depends on dial-core ^0.13a0 due to the addition of the (duplicate_nodes) method.
